### PR TITLE
remove ordered_model from INSTALLED_APPS

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -45,7 +45,6 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "ordered_model",
     "treebeard",
     "cpmonitor.apps.CpmonitorConfig",
 ]


### PR DESCRIPTION
django-ordered-model was removed from dependencies (poetry) in commit 9596629, but forgotten to remove from INSTALLED_APPS thus causing a ModuleNotFoundError when starting up the server in a fresh installation