### PR TITLE
80 djlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     rev: v1.19.6
     hooks:
       - id: djlint-django
+        args: ['--reformat', '--lint']
 # - repo: https://github.com/RobertCraigie/pyright-python
   # rev: v1.1.292
   # hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ build-backend = "poetry.core.masonry.api"
 [tool.pytest.ini_options]
 base_url = "http://localhost"
 DJANGO_SETTINGS_MODULE = "config.settings.local-container"
+
+[tool.djlint]
+ignore = "H017,H031"
+indent = 4
+quiet = true


### PR DESCRIPTION
adds to #80 

I realised that djlint does not format by default, it needs to be switched on explicitely by command line parameter
I also tweaked some configuration values, setting indentation and turning of unnecessary linter rules