### PR TITLE
#92 skip no-commit-to-branch in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           poetry install --with dev
           poetry run playwright install --with-deps chromium
       - name: Run pre-commit hooks on all files
-        run: poetry run pre-commit run --all-files
+        run: SKIP=no-commit-to-branch poetry run pre-commit run --all-files
       - name: create database
         run: poetry run python manage.py migrate --settings=config.settings.local
       - name: fill database


### PR DESCRIPTION
Fix for #92. Otherwise, merges to `main` will cause a failed CI run.