### PR TITLE
[#21] Prepare deploy workflow with ssh access to servers.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy
+on:
+  push:
+    branches: [deploy-to-production, deploy-to-test]
+  workflow_dispatch:
+
+jobs:
+  get-environment:
+    name: Get GitHub Environment
+    # Determine the GitHub "Environment" to be used by the "deploy" job.
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.do-it.outputs.environment }}
+      url:         ${{ steps.do-it.outputs.url }}
+    steps:
+      - id: do-it
+        name: Determine environment
+        run: |
+          case $GITHUB_REF in
+          refs/heads/deploy-to-production)
+            echo "environment=production"
+            echo "url=https://monitoring.localzero.net/";;
+          refs/heads/deploy-to-test)
+            echo "environment=test"
+            echo "url=https://monitoring-test.localzero.net/";;
+          *)
+            echo "";;
+          esac >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to ${{ needs.get-environment.outputs.environment }}
+    runs-on: ubuntu-latest
+    needs: get-environment
+    environment:
+      name: ${{ needs.get-environment.outputs.environment }}
+      url:  ${{ needs.get-environment.outputs.url }}
+    env:
+      ENVIRONMENT: ${{ needs.get-environment.outputs.environment }}
+      URL: ${{ needs.get-environment.outputs.url }}
+      DIR: ${{ vars.DEPLOY_TO_DIR }} # Set here: https://github.com/GermanZero-de/klimaschutzmonitor/settings/variables/actions
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # TODO: Build whatever is needed for the deployment here.
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          name: id_lzm
+          key: ${{ secrets.LZM_SSH_PRIVATE_KEY }}
+          known_hosts: ${{ secrets.LZM_SSH_KNOWN_HOSTS }}
+          config: |
+            Host lzm
+                HostName monitoring.localzero.net
+                User monitoring
+                IdentityFile ~/.ssh/id_lzm
+
+      # TODO: Do the actual deployment here and remove the test steps below.
+
+      - name: Test ssh connection (to be removed)
+        run: ssh lzm "echo \"$DIR - $URL - $GITHUB_REF - $GITHUB_SHA\" >> auto_deploy_test_file"
+      - name: Test conditional deployment 1 (to be removed)
+        if: ${{ env.ENVIRONMENT == 'production' }}
+        run: echo 'TODO Deploy production system'
+      - name: Test conditional deployment 2 (to be removed)
+        if: ${{ env.ENVIRONMENT == '' }}
+        run: echo 'Not really a true deployment'


### PR DESCRIPTION
This is only a small part of #21...

Apart from this PR I did some stuff here on GitHub:
- Added two [environments](https://github.com/GermanZero-de/klimaschutzmonitor/settings/environments).
- Added the needed SSH stuff in the repository [secrets](https://github.com/GermanZero-de/klimaschutzmonitor/settings/secrets/actions)
- Added an example variable `DEPLOY_TO_DIR` both as "[repository variable](https://github.com/GermanZero-de/klimaschutzmonitor/settings/variables/actions)" and as "environment variable". (The latter will overwrite the former.)

All this and also the extra job "Get Environment" in the workflow lead to this nice little thingy on the GitHub main page:

![image](https://user-images.githubusercontent.com/31070920/232523736-a25ec7e1-bf80-4076-900e-aec8d3e1f938.png)


I tried my best  to achieve the following: I wanted to have a single job for both deployments to production and test. Differences between the two should be controlled by variables. Since the environment needs to be set before any if statements, a separate job was needed to perform the step that determines the `environment` and `url` from the branch name.

It might turn out that the differences are a little bigger. Then, it might be much easier to have two jobs. One for deployment to test and one for production. No complicated ifs and environment / variable stuff would be needed. They could be either in the  same file with an if at the beginning ensuring they run only on the correct branch, or they could even be in separate files.