### PR TITLE
#30 tls certs

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -11,7 +11,7 @@ DJANGO_DEBUG=False
 # overwrite secret key on testing server .env here:
 DJANGO_SECRET_KEY=placeholder-override-me
 
-DJANGO_CSRF_TRUSTED_ORIGINS=https://monitoring-test.localzero.net
+DJANGO_CSRF_TRUSTED_ORIGINS=https://monitoring-test.localzero.net,https://monitoring.localzero.net
 
 # set admin login for dbeaver:
 CB_ADMIN_NAME=

--- a/README.md
+++ b/README.md
@@ -451,11 +451,11 @@ configured in the respective .env files on the server.
 ### TLS Certificate and Renewal
 We currently use a single TLS certificate for both monitoring.localzero.org and monitoring-test.localzero.org. The certificate is issued by letsencrypt.org and requesting and renewal is performed using [acme.sh](https://github.com/acmesh-official/acme.sh), which runs in a container. This solution allows us to have almost all necessary code and config in the repo instead of only on the server.
 
-Renewal is triggered by a cron job which can be viewed by executing the following on the server:
+Renewal is triggered by a cron job which can be found in [crontab](crontab) or by executing the following on the server:
 ```sh
 crontab -l
 ```
-The cron job tells the acme.sh container to perform a renewal twice a day (with some offset from 00:00 and 12:00 to not DDOS letsencrypt). acme.sh then...
+The cron job runs [a script](renew-cert.sh) that tells the acme.sh container to perform a renewal twice a day (with some offset from 00:00 and 12:00 to not DDOS letsencrypt). acme.sh then...
 - checks if a renewal is necessary, and if so:
 - requests a new certificate from letsencrypt,
 - performs the challenge-response-mechanism to verify ownership of the domain,

--- a/README.md
+++ b/README.md
@@ -271,7 +271,9 @@ SKIP=check-untracked-migrations git commit
 The application is deployed to the server as a pair of Docker containers:
 
 - container 1 runs the gunicorn webserver to host the django app itself,
-- container 2 runs nginx, a proxy that hosts the static files while providing stability and security.
+- container 2 runs nginx, a proxy that hosts the static files while providing stability and security,
+- container 3 runs the server for the database web client (Cloudbeaver),
+- container 4 runs acme.sh, which handles SSL certificate renewal.
 
 Only the port of nginx is exposed, which will forward requests to the django app or provide any requested static files directly.
 

--- a/README.md
+++ b/README.md
@@ -388,19 +388,28 @@ Commit the result.
     git tag -a deploy-test-${DATESTR} -m "Deployment to test" && git push origin deploy-test-${DATESTR}
     ```
 
-3. Build the image for the Django app: `docker compose build`
+3. Build the image for the Django app:
+    ```sh
+    docker compose build
+    ```
 4. Export the images:
-```
-docker save cpmonitor -o cpmonitor.tar
-docker save klimaschutzmonitor-dbeaver -o klimaschutzmonitor-dbeaver.tar
-```
-5. Copy the images and the compose file to the server: `scp -C cpmonitor.tar klimaschutzmonitor-dbeaver.tar docker-compose.yml monitoring@monitoring.localzero.net:/tmp/`
-6. Login to the server: `ssh monitoring@monitoring.localzero.net`
+    ```
+    docker save cpmonitor -o cpmonitor.tar
+    docker save klimaschutzmonitor-dbeaver -o klimaschutzmonitor-dbeaver.tar
+    ```
+5. Copy the images and the compose file to the server:
+    ```sh
+    scp -C cpmonitor.tar klimaschutzmonitor-dbeaver.tar docker-compose.yml monitoring@monitoring.localzero.net:/tmp/
+    ```
+6. Login to the server:
+    ```sh
+    ssh monitoring@monitoring.localzero.net
+    ```
 7. Import the images into Docker on the server:
-```
-docker load -i /tmp/cpmonitor.tar
-docker load -i /tmp/klimaschutzmonitor-dbeaver.tar
-```
+    ```
+    docker load -i /tmp/cpmonitor.tar
+    docker load -i /tmp/klimaschutzmonitor-dbeaver.tar
+    ```
 (Docker should print "Loading layer" for both images.)
 8. Tag the images with the current date in case we want to roll back:
 

--- a/config/nginx/conf.d/nginx.conf
+++ b/config/nginx/conf.d/nginx.conf
@@ -5,6 +5,24 @@ server {
 
     server_name monitoring.localzero.net monitoring-test.localzero.net;
 
+    location /.well-known/acme-challenge/ {
+        # pass certificate renewal requests to acme-sh container
+        proxy_pass http://acme-sh:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location / {
+        # respond with redirect to https port to all other requests
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 8443 ssl;
+
+    server_name monitoring.localzero.net monitoring-test.localzero.net;
+
     client_max_body_size 100m;
 
     location / {
@@ -29,6 +47,17 @@ server {
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+
+    ssl_certificate /etc/letsencrypt/ssl-cert.cer;
+    ssl_certificate_key /etc/letsencrypt/ssl-cert.key;
+
+    # SSL settings recommended by certbot as of May 2023 (https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf)
+    ssl_session_cache shared:le_nginx_SSL:10m;
+    ssl_session_timeout 1440m;
+    ssl_session_tickets off;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
 
     # include additional environment-specific configuration
     include /etc/nginx/conf.d/extras/extras.conf;

--- a/crontab
+++ b/crontab
@@ -1,0 +1,2 @@
+# renew certificate around every midnight and noon, if necessary
+0 0,12 * * * sleep 3109 && /home/monitoring/renew-cert.sh > /home/monitoring/last_cert_renewal.log 2>&1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3'
 services:
   djangoapp:
     container_name: djangoapp-${ENVIRONMENT_NAME}
-    # find a way so we dont have to toggle this on the server
     build:
       context: ./
       dockerfile: ./docker/cpmonitor/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,16 @@ services:
       - ${CERTIFICATES_PATH?:Please set the CERTIFICATES_PATH environment variable.}:/etc/letsencrypt
     depends_on:
       - djangoapp
+      - acme-sh
+    networks:
+      - nginx_network
+
+  acme-sh:
+    image: neilpang/acme.sh
+    container_name: acme-sh
+    command: daemon
+    volumes:
+      - ${CERTIFICATES_PATH?:Please set the CERTIFICATES_PATH environment variable.}:/acme.sh
     networks:
       - nginx_network
 

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -7,6 +7,12 @@ from playwright.sync_api import Page, BrowserContext
 from config.settings.base import BASE_DIR
 
 
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args):
+    # ignore complaints that our self-signed localhost cert isn't trusted by playwright
+    return {**browser_context_args, "ignore_https_errors": True}
+
+
 @pytest.fixture(scope="function")
 def django_db_setup(django_db_setup, django_db_blocker):
     with django_db_blocker.unblock():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires = ["poetry-core>=1.3.2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-base_url = "http://localhost"
+base_url = "https://localhost"
 env = [
     "DJANGO_SETTINGS_MODULE=config.settings.container",
     "DJANGO_SECRET_KEY=somePlaceholder",

--- a/renew-cert.sh
+++ b/renew-cert.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# fail on error
+set -x
+
+docker exec acme-sh --renew -d monitoring-test.localzero.net -d monitoring.localzero.net \
+    --standalone --server https://acme-v02.api.letsencrypt.org/directory \
+    --cert-file /acme.sh/ssl-cert.cer --key-file /acme.sh/ssl-cert.key
+docker exec nginx-testing nginx -s reload


### PR DESCRIPTION
Part of #30 - adds a container that can do certificate renewal when triggered by a cron job (still to be documented and installed on the server).

I had to deploy this on the server to test, and it's working now for both testing and production with the same certificate. I used my own mail adress for notifications for now. The cert is valid for 60 days, until which we should have finished installing the cronjob.