### PR TITLE
[#249] fix exception on missing local group

### DIFF
--- a/cpmonitor/templates/city.html
+++ b/cpmonitor/templates/city.html
@@ -9,7 +9,9 @@
       <h1>Monitoring für {{ city.name }}</h1>
     </div>
     <div class="col-auto">
-      <span class="align-middle">von <a href="{% url 'local_group' city.slug %}">{{ local_group.name }}</a></span>
+      {% if local_group %}
+        <span class="align-middle">von <a href="{% url 'local_group' city.slug %}">{{ local_group.name }}</a></span>
+      {% endif %}
     </div>
   </div>
   <div class="row row-deck row-cards">

--- a/cpmonitor/views.py
+++ b/cpmonitor/views.py
@@ -132,7 +132,7 @@ def city_view(request, city_slug):
             "asmt_admin": city.assessment_administration,
             "asmt_plan": city.assessment_action_plan,
             "asmt_status": city.assessment_status,
-            "local_group": city.local_group,
+            "local_group": getattr(city, "local_group", None),
         }
     )
 


### PR DESCRIPTION
closes #249 

I fixed the exception by simply not displaying local group info. However, I think we should consider hiding the city altogether (as if it was in draft mode), because the local group info is important with respect to responsibility for the data

If you agree, please add a note to #239 that already deals with this question