### PR TITLE
Add automated deployment script that runs on push to branches

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.env
+.env.*
 .git
 .gitignore
 .pre-commit-config.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
         run: poetry run python manage.py migrate --settings=config.settings.local
       - name: fill database
         run: poetry run python manage.py loaddata --settings=config.settings.local e2e_tests/database/test_database.json
+      - name: create networks
+        run: |
+          docker network create testing_nginx_network
+          docker network create production_nginx_network
       - name: start reverse-proxy
         run: docker compose -f docker/reverseproxy/docker-compose.yml up -d --build
       - name: build testing application

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,7 @@ on:
 
 jobs:
   get-environment:
-    name: Get GitHub Environment
-    # Determine the GitHub "Environment" to be used by the "deploy" job.
+    name:  Determine the environment for the deployment from the branch name
     runs-on: ubuntu-latest
     outputs:
       environment: ${{ steps.determine-environment.outputs.environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy
 on:
   push:
-    branches: [deploy-to-production, deploy-to-test]
+    branches: [deploy-to-testing, deploy-to-production]
   workflow_dispatch:
 
 jobs:
@@ -10,21 +10,24 @@ jobs:
     # Determine the GitHub "Environment" to be used by the "deploy" job.
     runs-on: ubuntu-latest
     outputs:
-      environment: ${{ steps.do-it.outputs.environment }}
-      url:         ${{ steps.do-it.outputs.url }}
+      environment: ${{ steps.determine-environment.outputs.environment }}
+      url:         ${{ steps.determine-environment.outputs.url }}
     steps:
-      - id: do-it
+      - id: determine-environment
         name: Determine environment
         run: |
           case $GITHUB_REF in
           refs/heads/deploy-to-production)
             echo "environment=production"
-            echo "url=https://monitoring.localzero.net/";;
-          refs/heads/deploy-to-test)
-            echo "environment=test"
-            echo "url=https://monitoring-test.localzero.net/";;
+            echo "url=https://monitoring.localzero.net/"
+            ;;
+          refs/heads/deploy-to-testing)
+            echo "environment=testing"
+            echo "url=https://monitoring-test.localzero.net/"
+            ;;
           *)
-            echo "";;
+            echo "not an environment: $GITHUB_REF - should be refs/heads/deploy-to-{testing|production}"
+            ;;
           esac >> $GITHUB_OUTPUT
 
   deploy:
@@ -42,8 +45,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # TODO: Build whatever is needed for the deployment here.
-
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:
@@ -56,13 +57,8 @@ jobs:
                 User monitoring
                 IdentityFile ~/.ssh/id_lzm
 
-      # TODO: Do the actual deployment here and remove the test steps below.
-
-      - name: Test ssh connection (to be removed)
-        run: ssh lzm "echo \"$DIR - $URL - $GITHUB_REF - $GITHUB_SHA\" >> auto_deploy_test_file"
-      - name: Test conditional deployment 1 (to be removed)
-        if: ${{ env.ENVIRONMENT == 'production' }}
-        run: echo 'TODO Deploy production system'
-      - name: Test conditional deployment 2 (to be removed)
-        if: ${{ env.ENVIRONMENT == '' }}
-        run: echo 'Not really a true deployment'
+      - name: Run deploy script
+        shell: bash
+        run: |
+          chmod u+x deploy.sh
+          ./deploy.sh "$ENVIRONMENT"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ python -m venv .venv
 poetry shell
 poetry install --sync
 pre-commit install
+docker network create testing_nginx_network
+docker network create production_nginx_network
 ```
 
 This will

--- a/README.md
+++ b/README.md
@@ -443,21 +443,14 @@ docker compose up -d
 
 ### Deploying a new version
 
-Requirement: SSH access to the server.
-
-Run [.github/workflows/deploy.sh](.github/workflows/deploy.sh) and provide the environment to deploy to as an argument:
-
-```shell
-./deploy.sh testing
+To deploy a new version to the testing or production environments, merge or push the commit you want to deploy to the corresponding branch:
 ```
-
-Optionally, you can specify a suffix for the tags that will be created, e.g. to differentiate multiple deployments on the same day:
-
-```shell
-./deploy.sh testing hotfix-for-issue-123
+deploy-to-testing
+deploy-to-production
 ```
+Note that only maintainers and admins may merge/push to those branches.
 
-View the script to see the exact steps that are executed.
+View the [workflow](.github/workflows/deploy.yml) and [script](deploy.sh) to see the exact steps that are executed.
 
 ### Database Client
 In order to view, manipulate and export the database in any of the environments (local, testing, production), the database webclient

--- a/deploy.sh
+++ b/deploy.sh
@@ -39,7 +39,10 @@ docker load -i /tmp/klimaschutzmonitor-dbeaver.tar
 
 # 8
 docker tag cpmonitor:latest cpmonitor:${date}${tag_suffix}
+docker tag cpmonitor:latest cpmonitor:${env}
+
 docker tag klimaschutzmonitor-dbeaver:latest klimaschutzmonitor-dbeaver:${date}${tag_suffix}
+docker tag klimaschutzmonitor-dbeaver:latest klimaschutzmonitor-dbeaver:${env}
 
 # 9
 cd ~/${env}/
@@ -52,6 +55,9 @@ docker run --user=1007:1007 --rm -it -v /home/monitoring/${env}/db:/db cpmonitor
 DJANGO_SECRET_KEY=whatever DJANGO_CSRF_TRUSTED_ORIGINS=https://whatever DJANGO_DEBUG=False python manage.py migrate --settings=config.settings.container
 # exit and stop the temporary container
 exit
+
+# TODO: it stops here for some reason..
+
 # use the latest docker-compose.yml to start the app using the new image
 mv docker-compose.yml docker-compose.yml.bak && cp /tmp/docker-compose.yml .
 docker-compose up --detach --no-build

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,10 +9,14 @@ fi
 
 env="${1:-}"
 tag_suffix="${2:-}"
+if [[ -n "$tag_suffix" ]]; then
+    # add leading dash
+    tag_suffix=${tag_suffix/#/-}
+fi
 
 # 2
 date=$(date +%Y-%b-%d)
-tag="deploy-${env}-${date}-${tag_suffix}"
+tag="deploy-${env}-${date}${tag_suffix}"
 echo "Tagging version as $tag in git."
 git tag -a $tag -m "Deployment to test" && git push origin $tag
 
@@ -34,15 +38,15 @@ docker load -i /tmp/cpmonitor.tar
 docker load -i /tmp/klimaschutzmonitor-dbeaver.tar
 
 # 8
-docker tag cpmonitor:latest cpmonitor:${date}-${tag_suffix}
-docker tag klimaschutzmonitor-dbeaver:latest klimaschutzmonitor-dbeaver:${date}-${tag_suffix}
+docker tag cpmonitor:latest cpmonitor:${date}${tag_suffix}
+docker tag klimaschutzmonitor-dbeaver:latest klimaschutzmonitor-dbeaver:${date}${tag_suffix}
 
 # 9
 cd ~/${env}/
 docker-compose down --volumes
 # backup the db
-cp -v db/db.sqlite3 /data/LocalZero/DB_BACKUPS/${env}/db.sqlite3.${date}-${tag_suffix}
-cp -vr cpmonitor/images/uploads /data/LocalZero/DB_BACKUPS/testing/uploads.${date}-${tag_suffix}
+cp -v db/db.sqlite3 /data/LocalZero/DB_BACKUPS/${env}/db.sqlite3.${date}${tag_suffix}
+cp -vr cpmonitor/images/uploads /data/LocalZero/DB_BACKUPS/testing/uploads.${date}${tag_suffix}
 # apply migrations using a temporary container
 docker run --user=1007:1007 --rm -it -v /home/monitoring/${env}/db:/db cpmonitor:latest sh
 DJANGO_SECRET_KEY=whatever DJANGO_CSRF_TRUSTED_ORIGINS=https://whatever DJANGO_DEBUG=False python manage.py migrate --settings=config.settings.container

--- a/deploy.sh
+++ b/deploy.sh
@@ -18,7 +18,7 @@ fi
 date=$(date +%Y-%b-%d)
 tag="deploy-${env}-${date}${tag_suffix}"
 echo "Tagging version as $tag in git."
-git tag -a $tag -m "Deployment to test" && git push origin $tag
+git tag -a $tag -m "Deployment to ${env}" && git push origin $tag
 
 #3
 docker compose build

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+if [[ "${1:-}" != "testing" && "${1:-}" != "production" ]]; then
+    echo "Please provide an environment as the first argument - either \"testing\" or \"production\"!"
+    exit 1
+fi
+
+env="${1:-}"
+
+# 2
+DATESTR=$(date +%Y-%b-%d) && echo "Using timestamp ${DATESTR}."
+git tag -a deploy-${env}-${DATESTR} -m "Deployment to test" && git push origin deploy-${env}-${DATESTR}
+
+#3
+docker compose build
+
+# 4
+docker save cpmonitor -o cpmonitor.tar
+docker save klimaschutzmonitor-dbeaver -o klimaschutzmonitor-dbeaver.tar
+
+# 5
+scp -C cpmonitor.tar klimaschutzmonitor-dbeaver.tar docker-compose.yml crontab renew-cert.sh monitoring@monitoring.localzero.net:/tmp/
+
+# 6
+ssh lzm /bin/bash << EOF
+
+# 7
+docker load -i /tmp/cpmonitor.tar
+docker load -i /tmp/klimaschutzmonitor-dbeaver.tar
+
+# 8
+docker tag cpmonitor:latest cpmonitor:${DATESTR}
+docker tag klimaschutzmonitor-dbeaver:latest klimaschutzmonitor-dbeaver:${DATESTR}
+
+# 9
+cd ~/${env}/
+docker-compose down --volumes
+# backup the db
+cp -v db/db.sqlite3 /data/LocalZero/DB_BACKUPS/${env}/db.sqlite3.${DATESTR}
+cp -vr cpmonitor/images/uploads /data/LocalZero/DB_BACKUPS/testing/uploads.${DATESTR}
+# apply migrations using a temporary container
+docker run --user=1007:1007 --rm -it -v $(pwd)/db:/db cpmonitor:latest sh
+DJANGO_SECRET_KEY=whatever DJANGO_CSRF_TRUSTED_ORIGINS=https://whatever DJANGO_DEBUG=False python manage.py migrate --settings=config.settings.container
+# exit and stop the temporary container
+exit
+# use the latest docker-compose.yml to start the app using the new image
+mv docker-compose.yml docker-compose.yml.bak && cp /tmp/docker-compose.yml .
+docker-compose up --detach --no-build
+
+# 10
+crontab /tmp/crontab
+cp /tmp/renew-cert.sh /home/monitoring/
+chmod +x /home/monitoring/renew-cert.sh
+
+EOF

--- a/deploy.sh
+++ b/deploy.sh
@@ -43,6 +43,7 @@ docker load -i /tmp/cpmonitor.tar
 docker load -i /tmp/klimaschutzmonitor-dbeaver.tar
 
 # 8
+# TODO something about the tagging doesn't work as it should, do local tags not match what we expect here?
 docker tag cpmonitor:${env} cpmonitor:${date}${tag_suffix}
 docker tag klimaschutzmonitor-dbeaver:${env} klimaschutzmonitor-dbeaver:${date}${tag_suffix}
 
@@ -51,11 +52,10 @@ cd ~/${env}/
 docker-compose down --volumes
 # backup the db
 cp -v db/db.sqlite3 /data/LocalZero/DB_BACKUPS/${env}/db.sqlite3.${date}${tag_suffix}
-cp -vr cpmonitor/images/uploads /data/LocalZero/DB_BACKUPS/testing/uploads.${date}${tag_suffix}
+cp -vr cpmonitor/images/uploads /data/LocalZero/DB_BACKUPS/${env}/uploads.${date}${tag_suffix}
 # apply migrations using a temporary container
+# this doesn't seem to work like it should; migrations were not applied last time
 docker run --user=1007:1007 --rm -v /home/monitoring/${env}/db:/db cpmonitor:${env} sh -c "DJANGO_SECRET_KEY=whatever DJANGO_CSRF_TRUSTED_ORIGINS=https://whatever DJANGO_DEBUG=False python manage.py migrate --settings=config.settings.container"
-
-# TODO: it stops here for some reason..
 
 # use the latest docker-compose.yml to start the app using the new image
 mv docker-compose.yml docker-compose.yml.bak && cp /tmp/docker-compose.yml .
@@ -65,5 +65,9 @@ docker-compose up --detach --no-build
 crontab /tmp/crontab
 cp /tmp/renew-cert.sh /home/monitoring/
 chmod +x /home/monitoring/renew-cert.sh
+
+echo
+echo 'FINISHED SUCCESSFULLY!'
+echo
 
 EOF

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,7 +48,7 @@ docker-compose down --volumes
 cp -v db/db.sqlite3 /data/LocalZero/DB_BACKUPS/${env}/db.sqlite3.${date}${tag_suffix}
 cp -vr cpmonitor/images/uploads /data/LocalZero/DB_BACKUPS/testing/uploads.${date}${tag_suffix}
 # apply migrations using a temporary container
-docker run --user=1007:1007 --rm -it -v /home/monitoring/${env}/db:/db cpmonitor:${env} sh -c "DJANGO_SECRET_KEY=whatever DJANGO_CSRF_TRUSTED_ORIGINS=https://whatever DJANGO_DEBUG=False python manage.py migrate --settings=config.settings.container"
+docker run --user=1007:1007 --rm -v /home/monitoring/${env}/db:/db cpmonitor:${env} sh -c "DJANGO_SECRET_KEY=whatever DJANGO_CSRF_TRUSTED_ORIGINS=https://whatever DJANGO_DEBUG=False python manage.py migrate --settings=config.settings.container"
 
 # TODO: it stops here for some reason..
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -33,7 +33,7 @@ docker save cpmonitor -o cpmonitor.tar
 docker save klimaschutzmonitor-dbeaver -o klimaschutzmonitor-dbeaver.tar
 
 # 5
-scp -C cpmonitor.tar klimaschutzmonitor-dbeaver.tar docker-compose.yml crontab renew-cert.sh monitoring@monitoring.localzero.net:/tmp/
+scp -C cpmonitor.tar klimaschutzmonitor-dbeaver.tar docker-compose.yml crontab reload-cert.sh monitoring@monitoring.localzero.net:/tmp/
 
 ssh -tt lzm /bin/bash << EOF
 set -euo pipefail
@@ -63,8 +63,8 @@ docker-compose up --detach --no-build
 
 # 10
 crontab /tmp/crontab
-cp /tmp/renew-cert.sh /home/monitoring/
-chmod +x /home/monitoring/renew-cert.sh
+cp /tmp/reload-cert.sh /home/monitoring/
+chmod +x /home/monitoring/reload-cert.sh
 
 echo
 echo 'FINISHED SUCCESSFULLY!'

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,7 +30,7 @@ docker compose --env-file .env.${env} build
 
 # Export the images
 docker save cpmonitor:${env} -o cpmonitor.tar
-docker save klimaschutzmonitor-dbeaver -o klimaschutzmonitor-dbeaver.tar
+docker save klimaschutzmonitor-dbeaver:${env} -o klimaschutzmonitor-dbeaver.tar
 
 # Copy the images, the compose files, the certificate renewal cron job and the reverse proxy settings to the server
 scp -C -r cpmonitor.tar klimaschutzmonitor-dbeaver.tar docker-compose.yml crontab reload-cert.sh docker/reverseproxy/ monitoring@monitoring.localzero.net:/tmp/
@@ -45,8 +45,8 @@ docker load -i /tmp/klimaschutzmonitor-dbeaver.tar
 
 # Tag the images with the current date in case we want to roll back,
 # as well as with the environment you're deploying to (to prevent affecting the other environment)
-docker tag cpmonitor:${env} cpmonitor:${date}${tag_suffix}
-docker tag klimaschutzmonitor-dbeaver:${env} klimaschutzmonitor-dbeaver:${date}${tag_suffix}
+docker tag cpmonitor:${env} cpmonitor:${env}-${date}${tag_suffix}
+docker tag klimaschutzmonitor-dbeaver:${env} klimaschutzmonitor-dbeaver:${env}-${date}${tag_suffix}
 
 # Stop the server, apply the migrations, start the server
 cd ~/${env}/

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,19 +30,16 @@ docker save klimaschutzmonitor-dbeaver -o klimaschutzmonitor-dbeaver.tar
 # 5
 scp -C cpmonitor.tar klimaschutzmonitor-dbeaver.tar docker-compose.yml crontab renew-cert.sh monitoring@monitoring.localzero.net:/tmp/
 
-# 6 - TODO: fail on error also within the SSH session (move this part to an scp'd script..?)
 ssh -tt lzm /bin/bash << EOF
+set -euo pipefail
 
 # 7
 docker load -i /tmp/cpmonitor.tar
 docker load -i /tmp/klimaschutzmonitor-dbeaver.tar
 
 # 8
-docker tag cpmonitor:latest cpmonitor:${date}${tag_suffix}
-docker tag cpmonitor:latest cpmonitor:${env}
-
-docker tag klimaschutzmonitor-dbeaver:latest klimaschutzmonitor-dbeaver:${date}${tag_suffix}
-docker tag klimaschutzmonitor-dbeaver:latest klimaschutzmonitor-dbeaver:${env}
+docker tag cpmonitor:${env} cpmonitor:${date}${tag_suffix}
+docker tag klimaschutzmonitor-dbeaver:${env} klimaschutzmonitor-dbeaver:${date}${tag_suffix}
 
 # 9
 cd ~/${env}/
@@ -51,10 +48,7 @@ docker-compose down --volumes
 cp -v db/db.sqlite3 /data/LocalZero/DB_BACKUPS/${env}/db.sqlite3.${date}${tag_suffix}
 cp -vr cpmonitor/images/uploads /data/LocalZero/DB_BACKUPS/testing/uploads.${date}${tag_suffix}
 # apply migrations using a temporary container
-docker run --user=1007:1007 --rm -it -v /home/monitoring/${env}/db:/db cpmonitor:latest sh
-DJANGO_SECRET_KEY=whatever DJANGO_CSRF_TRUSTED_ORIGINS=https://whatever DJANGO_DEBUG=False python manage.py migrate --settings=config.settings.container
-# exit and stop the temporary container
-exit
+docker run --user=1007:1007 --rm -it -v /home/monitoring/${env}/db:/db cpmonitor:${env} sh -c "DJANGO_SECRET_KEY=whatever DJANGO_CSRF_TRUSTED_ORIGINS=https://whatever DJANGO_DEBUG=False python manage.py migrate --settings=config.settings.container"
 
 # TODO: it stops here for some reason..
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,7 +26,7 @@ echo "Tagging version as $tag in git."
 git tag -a $tag -m "Deployment to ${env}" && git push origin $tag
 
 #3
-docker compose build
+docker compose --env-file .env.${env} build
 
 # 4
 docker save cpmonitor -o cpmonitor.tar
@@ -43,7 +43,6 @@ docker load -i /tmp/cpmonitor.tar
 docker load -i /tmp/klimaschutzmonitor-dbeaver.tar
 
 # 8
-# TODO something about the tagging doesn't work as it should, do local tags not match what we expect here?
 docker tag cpmonitor:${env} cpmonitor:${date}${tag_suffix}
 docker tag klimaschutzmonitor-dbeaver:${env} klimaschutzmonitor-dbeaver:${date}${tag_suffix}
 
@@ -54,7 +53,6 @@ docker-compose down --volumes
 cp -v db/db.sqlite3 /data/LocalZero/DB_BACKUPS/${env}/db.sqlite3.${date}${tag_suffix}
 cp -vr cpmonitor/images/uploads /data/LocalZero/DB_BACKUPS/${env}/uploads.${date}${tag_suffix}
 # apply migrations using a temporary container
-# this doesn't seem to work like it should; migrations were not applied last time
 docker run --user=1007:1007 --rm -v /home/monitoring/${env}/db:/db cpmonitor:${env} sh -c "DJANGO_SECRET_KEY=whatever DJANGO_CSRF_TRUSTED_ORIGINS=https://whatever DJANGO_DEBUG=False python manage.py migrate --settings=config.settings.container"
 
 # use the latest docker-compose.yml to start the app using the new image

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 if [[ "${1:-}" != "testing" && "${1:-}" != "production" ]]; then
     echo "Please provide an environment as the first argument - either \"testing\" or \"production\"!"
+    echo "You may additionally pass in a tag suffix as second parameter that will be appended to today's date in the git and docker tags."
+    echo
+    echo "For example,"
+    echo "$ ./deploy.sh testing bugfix"
+    echo "will create tags like \"deploy-testing-2023-Aug-05-bugfix\"."
     exit 1
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -33,7 +33,7 @@ docker save cpmonitor:${env} -o cpmonitor.tar
 docker save klimaschutzmonitor-dbeaver -o klimaschutzmonitor-dbeaver.tar
 
 # Copy the images, the compose files, the certificate renewal cron job and the reverse proxy settings to the server
-scp -C cpmonitor.tar klimaschutzmonitor-dbeaver.tar docker-compose.yml crontab reload-cert.sh monitoring@monitoring.localzero.net:/tmp/
+scp -C -r cpmonitor.tar klimaschutzmonitor-dbeaver.tar docker-compose.yml crontab reload-cert.sh docker/reverseproxy/ monitoring@monitoring.localzero.net:/tmp/
 
 # Login to the server and execute everything that follows there
 ssh -tt lzm /bin/bash << EOF

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,7 +29,7 @@ git tag -a $tag -m "Deployment to ${env}" && git push origin $tag
 docker compose --env-file .env.${env} build
 
 # 4
-docker save cpmonitor -o cpmonitor.tar
+docker save cpmonitor:${env} -o cpmonitor.tar
 docker save klimaschutzmonitor-dbeaver -o klimaschutzmonitor-dbeaver.tar
 
 # 5
@@ -64,8 +64,8 @@ crontab /tmp/crontab
 cp /tmp/reload-cert.sh /home/monitoring/
 chmod +x /home/monitoring/reload-cert.sh
 
-echo
 echo 'FINISHED SUCCESSFULLY!'
-echo
+
+exit
 
 EOF

--- a/docker/reverseproxy/docker-compose.yml
+++ b/docker/reverseproxy/docker-compose.yml
@@ -30,9 +30,11 @@ networks:
   production_nginx_network:
     name: production_nginx_network
     driver: bridge
+    external: true
   testing_nginx_network:
     name: testing_nginx_network
     driver: bridge
+    external: true
   reverse_proxy_network:
     name: reverse_proxy_network
     driver: bridge


### PR DESCRIPTION
Part of #21 .

Adds a script that automatically performs all deployment steps currently documented in the README: it builds the app and container images, copies them, creates backups, stops old app version and starts the new one.

Copying over production data to testing is currently not documented and therefore not implemented.

I tested the deploy.yml workflow locally using [act](https://github.com/nektos/act) with some dummy values and it executed the deploy.sh script with the correct environment as argument. We have to see if the workflow works on github after we merge it though because only then can we actually run it here.