### PR TITLE
[#62] make statusbar tooltips accessible on touch devices

### DIFF
--- a/cpmonitor/static/js/main.js
+++ b/cpmonitor/static/js/main.js
@@ -3,3 +3,5 @@ const progressbars = document.querySelectorAll("div.progress-bar");
 progressbars.forEach(pb => {
   pb.style.width = pb.dataset.value + "%";
 });
+
+$('[data-bs-toggle="tooltip"]').click(function(e){e.preventDefault()})


### PR DESCRIPTION
closes #62

completes the last task of #62 and makes the tooltips accessible. They could always be accessed by simple touch. The problem was that the touch also triggered the link on the card and thus send the user to the subpage.
I added a line of javascript to prevent the default link behaviour. No you can touch/click the statusbar to see the tooltips and touch/click anywhere else on the card to get to the subpage