### PR TITLE
[#23] Existing users can use invitation link.

### DIFF
--- a/cpmonitor/admin.py
+++ b/cpmonitor/admin.py
@@ -118,7 +118,7 @@ class CityAdmin(ObjectPermissionsModelAdminMixin, admin.ModelAdmin):
         user = request.user
         if user.is_superuser:
             return qs
-        return qs.filter(rules.is_allowed_to_edit_q(user, City))
+        return qs.filter(rules.is_allowed_to_edit_q(user, City)).distinct()
 
     @admin.display(description="")
     def edit_tasks(self, city: City):
@@ -320,7 +320,7 @@ class TaskAdmin(ObjectPermissionsModelAdminMixin, TreeAdmin):
         if db_field.name == "city":
             kwargs["queryset"] = City.objects.filter(
                 rules.is_allowed_to_edit_q(request.user, City)
-            )
+            ).distinct()
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     def get_changeform_initial_data(self, request: HttpRequest):

--- a/cpmonitor/templates/invitations/messages/invite_for_logged_in_user.txt
+++ b/cpmonitor/templates/invitations/messages/invite_for_logged_in_user.txt
@@ -1,0 +1,3 @@
+{% autoescape off %}
+Nutzer {{username}} ist eingeloggt und ist jetzt auch {{role}} von {{city}}.
+{% endautoescape %}

--- a/cpmonitor/templates/invitations/messages/invite_for_logged_in_user_invalid.txt
+++ b/cpmonitor/templates/invitations/messages/invite_for_logged_in_user_invalid.txt
@@ -1,0 +1,3 @@
+{% autoescape off %}
+Nutzer {{username}} ist eingeloggt aber inaktiv. Bitte einen neuen Nutzer anlegen.
+{% endautoescape %}


### PR DESCRIPTION
This is a fix of small holes in #23. I probably should have entered new issue(s). Sorry for my lazyness.

Solved:
- If a (non-super-)user is both editor and admin for a city, the appeared twice in some lists, which lead to failures of some views. After this PR that is fine, but the city still appears twice in the filter list. New issue: #282
- If a user is logged in and uses an invitation link, it is rejected. After this PR the access right connected to the invitation link is added to the user.