### PR TITLE
[#284] Workaround: Remove content security policy for now

### DIFF
--- a/config/nginx/conf.d/nginx.conf
+++ b/config/nginx/conf.d/nginx.conf
@@ -8,7 +8,7 @@ server {
     server_name monitoring.localzero.net monitoring-test.localzero.net;
 
     client_max_body_size 100m;
-    add_header Content-Security-Policy "default-src 'self'";
+
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
     add_header Cache-Control "no-store";
 


### PR DESCRIPTION
Workaround for #284 - remove CSP header again until we find a real fix so we can deploy and people can keep working.