### PR TITLE
[#284] add content security header that works with martor

### DIFF
--- a/config/nginx/conf.d/nginx.conf
+++ b/config/nginx/conf.d/nginx.conf
@@ -11,6 +11,7 @@ server {
 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
     add_header Cache-Control "no-store";
+    add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline';img-src 'self' data:;";
 
     location / {
         # pass requests for dynamic content to gunicorn


### PR DESCRIPTION
closes #284 

I also added an issue at Martor: https://github.com/agusmakmun/django-markdown-editor/issues/218 