### PR TITLE
[#381] try to fix the martor image upload

### DIFF
--- a/cpmonitor/urls.py
+++ b/cpmonitor/urls.py
@@ -18,6 +18,9 @@ urlpatterns = [
         RedirectView.as_view(url=settings.STATIC_URL + "favicon.svg", permanent=True),
     ),
     path("admin/", admin.site.urls),
+    path(
+        "api/uploader/", views.markdown_uploader_view, name="markdown_uploader"
+    ),  # needs to be before the martor urls, so that our image uplaoder and not the imgur uploader is used
     path("martor/", include("martor.urls")),
     path("accounts/", include("allauth.urls")),
     re_path(
@@ -25,7 +28,6 @@ urlpatterns = [
         views.AcceptInvite.as_view(),
         name="accept-invite",
     ),
-    path("api/uploader/", views.markdown_uploader_view, name="markdown_uploader"),
     path("", views.index_view, name="index"),
     path(prefix_kommune + "<slug:city_slug>/", views.city_view, name="city"),
     path(


### PR DESCRIPTION
I could not reproduce this locally which I find confusing.
But my theory is that Martor calls the imgur uploader instead of our uploader because the url is added before ours. 