### PR TITLE
Improve wording of expand button and add collapse label

### DIFF
--- a/frontend/app/components/TileList.tsx
+++ b/frontend/app/components/TileList.tsx
@@ -46,10 +46,10 @@ interface TileListProps {
           ))}
     </div>
     <div className="block-text pb-3" onClick={toggle} style={{cursor:"pointer"}}>
-          {!showAll ? <div className="lh-4 py-4">Anzeige weiterer Kommunen</div> : <></>}
+          <div className="lh-4 py-4">{!showAll ? "weitere Kommunen" : "weniger"}</div>
           <Image
             src={showAll ? expandArrowUp : expandArrowDown}
-            alt="Anzeige weiterer Kommunen"
+            alt="weitere Kommunen"
           />
         </div>
     </div>


### PR DESCRIPTION
Improves the expand label for more cities from this:
![image](https://github.com/user-attachments/assets/6977c754-de90-44f8-acd8-c8ec92386cdd) to this: ![image](https://github.com/user-attachments/assets/f88f9831-aeac-4cb3-b2ce-d2b6a0915bdf)
and adds a collapse text that was missing:
![image](https://github.com/user-attachments/assets/1d08827d-3532-4318-b755-590d775ad7c8)
